### PR TITLE
Rename Makefile targets in terms of "shell", not "bash"

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -2,9 +2,9 @@ env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
 
 steps:
-  - label: ":lint-roller::bash: Lint Bash"
+  - label: ":lint-roller::bash: Lint Shell"
     command:
-      - make lint-bash
+      - make lint-shell
     plugins:
       - grapl-security/vault-login#v0.1.0
       - grapl-security/vault-env#v0.1.0:

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,24 @@ COMPOSE_USER=$(shell id -u):$(shell id -g)
 ########################################################################
 
 .PHONY: lint
-lint: lint-plugin lint-bash
+lint: lint-plugin lint-shell
 
 .PHONY: lint-plugin
 lint-plugin:
 	docker-compose run --rm plugin-linter
 
-.PHONY: lint-bash
-lint-bash:
+.PHONY: lint-shell
+lint-shell:
 	./pants lint ::
 
 # Formatting
 ########################################################################
 
 .PHONY: format
-format: format-bash
+format: format-shell
 
-.PHONY: format-bash
-format-bash:
+.PHONY: format-shell
+format-shell:
 	./pants fmt ::
 
 # Testing


### PR DESCRIPTION
This is more general, and in keeping with the pattern across the rest
of our repositories.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>