### PR TITLE
Update and lock Buildkite images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPOSE_USER=$(shell id -u):$(shell id -g)
+DOCKER_COMPOSE_CHECK := docker compose run --rm
 
 # Linting
 ########################################################################
@@ -8,7 +8,7 @@ lint: lint-plugin lint-shell
 
 .PHONY: lint-plugin
 lint-plugin:
-	docker-compose run --rm plugin-linter
+	$(DOCKER_COMPOSE_CHECK) plugin-linter
 
 .PHONY: lint-shell
 lint-shell:
@@ -32,7 +32,7 @@ test: test-plugin
 
 .PHONY: test-plugin
 test-plugin:
-	docker-compose run --rm plugin-tester
+	$(DOCKER_COMPOSE_CHECK) plugin-tester
 
 .PHONY: all
 all: format lint test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-common-variables:
   read-only-plugin: &read-only-plugin
     # Buildkite containers assume you mount into /plugin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-common-variables:
 
 services:
   plugin-tester:
-    image: buildkite/plugin-tester:latest # the only available tag
+    image: buildkite/plugin-tester:v2.0.0
     volumes:
       - *read-only-plugin
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - *read-only-plugin
 
   plugin-linter:
-    image: buildkite/plugin-linter:latest # the only available tag
+    image: buildkite/plugin-linter@sha256:833b1ce8326b038c748c8f04d317045205e115b1732a6842ec4a957f550fe357
     command: ["--id", "grapl-security/vault-env"]
     volumes:
       - *read-only-plugin


### PR DESCRIPTION
There's an official release for [`buildkite/plugin-tester`](https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v2.0.0) now. It updates several bits of BATS infrastructure, but also introduces a breaking change.

This PR locks us to the `v2.0.0` release of the `plugin-tester` image.

I also noticed that our use of the `buildkite/plugin-linter` image was also pinned to `latest`, just as our `buildkite/plugin-tester` image was. There are no formal release of this image (yet :crossed_fingers:), so I've pinned it to a concrete SHA to be safe.

While making these fixes, I also took the liberty of shifting our Docker Compose usage explicitly to v2, as we have been doing across all our projects lately.